### PR TITLE
Add User Not Found Exception

### DIFF
--- a/src/ACL.php
+++ b/src/ACL.php
@@ -6,6 +6,7 @@ namespace Aclify;
 use Symfony\Component\Yaml\Yaml;
 use Aclify\Exceptions\MissingACLSpecsFile;
 use Illuminate\Support\Collection;
+use Aclify\Exceptions\UserNotFoundException;
 
 class ACL
 {
@@ -32,6 +33,9 @@ class ACL
 
     public function rolesOf(string $user) : array 
     {
+        if(!isset($this->specs["users"][$user])){
+            throw new UserNotFoundException();
+        }
         return $this->specs["users"][$user];
     }
 

--- a/src/exceptions/UserNotFoundException.php
+++ b/src/exceptions/UserNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Aclify\Exceptions;
+
+class UserNotFoundException extends \Exception
+{
+    public function __construct($message = "", $code = 0, \Exception $previous = null)
+    {
+        parent::__construct("User not found", $code, $previous);
+    }
+
+    public function __toString()
+    {
+        return __class__ . ": [{$this->code}]: {$this->message}\n";
+    }
+}

--- a/tests/ACLTest.php
+++ b/tests/ACLTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 use Aclify\ACL;
 use Aclify\Exceptions\MissingACLSpecsFile;
 use Aclify\ACLUser;
+use \Aclify\Exceptions\UserNotFoundException;
 
 class ACLTest extends TestCase
 {
@@ -113,6 +114,12 @@ class ACLTest extends TestCase
         $advanced = new User($this->acl, "advanced");
         $abilities = $advanced->abilities();
         $this->assertEquals($abilities, ["mailchimp", "facebook", "payments", "pluto", "cms_tools", "pippo"]);
+    }
+
+    public function testUserNotFound() : void {
+        $this->expectException(UserNotFoundException::class);
+        $asdrubale = new User($this->acl, "asdrubale");
+        $abilities = $asdrubale->abilities();
     }
 
 }


### PR DESCRIPTION
Aggiunta una exception per gestire questo errore, generato quando manca l'utente nel file acl.yml

`Return value of Aclify\ACL::rolesOf() must be of the type array, null returned`